### PR TITLE
Update sarathi_scheduler.py

### DIFF
--- a/vllm/core/scheduler/sarathi_scheduler.py
+++ b/vllm/core/scheduler/sarathi_scheduler.py
@@ -25,7 +25,8 @@ class SarathiScheduler(BaseScheduler):
         self.prompt_limit = self.scheduler_config.max_model_len
         self.chunk_size = self.scheduler_config.chunk_size
         self.enable_rolling_prefills = self.scheduler_config.enable_rolling_prefills
-
+        self.prefill_fitting_tolerance = self.scheduler_config.prefill_fitting_tolerance
+        
     def _get_block_space_manager_class(self) -> Type[BaseBlockSpaceManager]:
         return SarathiBlockSpaceManager
 


### PR DESCRIPTION
This pull request addresses a bug found in a specific Python program where the attribute self.prefill_fitting_tolerance was referenced at line 48 without being initialized. The reference to self.prefill_fitting_tolerance resulted in an AttributeError because the attribute was not properly set up in the class constructor.

To overcome this issue, I added an initialization for self.prefill_fitting_tolerance to the SarathiSchedulerConfig class in config.py. The SarathiSchedulerConfig constructor now correctly assigns the value of the prefill_fitting_tolerance option to self.prefill_fitting_tolerance, ensuring that the attribute is properly populated prior to usage.